### PR TITLE
add gri (gradle idea command) and other git related shortcuts

### DIFF
--- a/all-about-that-bash.sh
+++ b/all-about-that-bash.sh
@@ -913,7 +913,7 @@ arclog() {
 }
 
 greset() {
-     git add .; git reset --hard;
+     git add .; git reset --hard ${1};
 }
 
 gfinds() {

--- a/all-about-that-bash.sh
+++ b/all-about-that-bash.sh
@@ -900,6 +900,11 @@ gfo() {
     git fetch --no-tags origin ${1};
 }
 
+gfor() {
+    currBranch=$(git branch | grep \* | cut -d ' ' -f2)
+    git fetch --no-tags origin $currBranch; git rebase;
+}
+
 gfo-endless() {
     while [ : ]
     do

--- a/all-about-that-bash.sh
+++ b/all-about-that-bash.sh
@@ -933,6 +933,13 @@ gcpa() {
      git cherry-pick --abort;
 }
 
+##change from flight/fpr-reschedule-booking-impl into ./gradlew flight:fpr-reschedule-booking-impl:idea
+gri() {
+  str=$(echo ${1} | sed "s/\//:/g" | xargs -I{} echo "./gradlew {}:idea")
+  echo "running $str";
+  $str;
+}
+
 
 
 trap 'echo -e "${clPURPLE}-- Started at $(date +"%H:%M:%S") --${cLIGHTGRAY}"' DEBUG

--- a/all-about-that-bash.sh
+++ b/all-about-that-bash.sh
@@ -905,14 +905,6 @@ gfor() {
     git fetch --no-tags origin $currBranch; git rebase;
 }
 
-gfo-endless() {
-    while [ : ]
-    do
-        git fetch --no-tags origin ${1};
-        sleep 30m
-    done
-}
-
 arclog() {
     arc patch ${1} ; git log;
 }
@@ -923,14 +915,6 @@ greset() {
 
 gfinds() {
      git branch -r --contains ${1};
-}
-
-gcp() {
-     git cherry-pick ${1};
-}
-
-gcpa() {
-     git cherry-pick --abort;
 }
 
 ##change from flight/fpr-reschedule-booking-impl into ./gradlew flight:fpr-reschedule-booking-impl:idea

--- a/all-about-that-bash.sh
+++ b/all-about-that-bash.sh
@@ -897,11 +897,37 @@ git-land() {
 }
 
 gfo() {
-    git fetch --no-tags origin 
+    git fetch --no-tags origin ${1};
+}
+
+gfo-endless() {
+    while [ : ]
+    do
+        git fetch --no-tags origin ${1};
+        sleep 30m
+    done
 }
 
 arclog() {
-    arc patch ${1} ; git log
+    arc patch ${1} ; git log;
 }
+
+greset() {
+     git add .; git reset --hard;
+}
+
+gfinds() {
+     git branch -r --contains ${1};
+}
+
+gcp() {
+     git cherry-pick ${1};
+}
+
+gcpa() {
+     git cherry-pick --abort;
+}
+
+
 
 trap 'echo -e "${clPURPLE}-- Started at $(date +"%H:%M:%S") --${cLIGHTGRAY}"' DEBUG


### PR DESCRIPTION
- add gri (gradle idea command) which can change from `flight/fpr-reschedule-booking-impl` into `./gradlew flight:fpr-reschedule-booking-impl:idea`. This way, you can just do copy relative path of the module folder, and then just type gri + paste that path for every module you want to build
- enhance gfo so that it could git fetch specific branch
- add gfor: gfo the current branch + rebase
- add greset: git reset --hard
- add gfinds: find which branch a commit hash is on